### PR TITLE
libxkbcommon 1.9.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/xkeyboard-config-feedstock/pr1/5c978e4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/xkeyboard-config-feedstock/pr1/5c978e4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - xorg-xorgproto
     - xcb-proto
     - pthread-stubs
-    - libxml2
+    - libxml2 {{ libxml2 }}
   run:
     - xkeyboard-config
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libxkbcommon" %}
-{% set version = "1.0.1" %}
+{% set version = "1.9.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,21 +7,18 @@ package:
 
 source:
   url: https://github.com/xkbcommon/{{ name }}/archive/xkbcommon-{{ version }}.tar.gz
-  sha256: 270e2ad4ce5699f633e49042114cb68a5697fa1ed45b65c1d96a833cfac20954
+  sha256: 763b914c4779e9579ab4d06caffff39cc8f43a1c126ec3b7a2f920bf9817097b
 
 build:
-  number: 2
-  # xorg-xproto missing on s390x,
-  skip: true  # [win or osx or (linux and (s390x or ppc64le))]
-  missing_dso_whitelist:
-    - /lib/libc.so.6
+  number: 0
+  skip: true  # [win or osx]
   run_exports:
     - {{ pin_subpackage('libxkbcommon') }}
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ cdt('libxau-devel') }}
+    - {{ compiler('cxx') }}
     - meson
     - ninja
     - m4
@@ -29,22 +26,33 @@ requirements:
     - cmake
     - pkg-config
   host:
+    - xorg-libxau
     - libxcb
-    - libxml2 {{ libxml2 }}
-    - xorg-xproto
+    - xorg-xorgproto
     - xcb-proto
     - pthread-stubs
+    - libxml2
+  run:
+    - xkeyboard-config
 
 test:
   commands:
     - test -f "${PREFIX}/lib/libxkbcommon${SHLIB_EXT}"
+    - xkbcli --help
+
+  # Check downstream packages if needed.
+  downstreams:
+    - qtbase
+    - qtwebengine
+    - nsight-compute
+    - qt-webengine
 
 about:
   home: https://github.com/xkbcommon/libxkbcommon
-  license: MIT AND X11
+  license: MIT/X11 Derivative
   license_family: MIT
   license_file: LICENSE
-  summary: 'keymap handling library for toolkits and window systems'
+  summary: keymap handling library for toolkits and window systems
   description: |
     libxkbcommon is a keyboard keymap compiler and support library which
     processes a reduced subset of keymaps as defined by the XKB (X Keyboard
@@ -55,3 +63,4 @@ about:
 extra:
   recipe-maintainers:
     - scopatz
+    - hmaarrfk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,14 +41,13 @@ test:
     - xkbcli --help
 
   # Check downstream packages if needed.
-  downstreams:
-    - qtbase
-    - qtwebengine
-    - nsight-compute
-    - qt-webengine
+  # downstreams:
+  #   - qtbase
+  #   - qtwebengine
+  #   - nsight-compute
 
 about:
-  home: https://github.com/xkbcommon/libxkbcommon
+  home: https://xkbcommon.org/
   license: MIT/X11 Derivative
   license_family: MIT
   license_file: LICENSE
@@ -57,7 +56,7 @@ about:
     libxkbcommon is a keyboard keymap compiler and support library which
     processes a reduced subset of keymaps as defined by the XKB (X Keyboard
     Extension) specification.
-  doc_url: https://xkbcommon.org/
+  doc_url: https://xkbcommon.org/doc/current/
   dev_url: https://github.com/xkbcommon/libxkbcommon
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ test:
 
 about:
   home: https://xkbcommon.org/
-  license: MIT/X11 Derivative
+  license: MIT AND X11
   license_family: MIT
   license_file: LICENSE
   summary: keymap handling library for toolkits and window systems


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7760](https://anaconda.atlassian.net/browse/PKG-7760) 
- [Upstream repository](https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.9.1)

### Explanation of changes:

- 

### Notes:

- I've tested downstream packages on linux-64:
	```
	ddb get-impact libxkbcommon 1.9.1 | jq -r -c ".[][] | [.name, .depends_on, .channel]"
	["qtbase","libxkbcommon >=1.0.1,<2.0a0","main"]
	["qtwebengine","libxkbcommon >=1.0.1,<2.0a0","main"]
	["nsight-compute","libxkbcommon >=1.0.1,<2.0a0","main"]
	["qt-webengine","libxkbcommon >=1.0.1,<2.0a0","main"]
	```
  - ✅ qtbase-6.7.3
  - ✅ qtwebengine-6.7.3
  - ✅ nsight-compute-2024.1.1.4
  - ❌ qt-webengine-5.15.9 (seems the issue with the recipe itself):
	```
	None INFO + bash /feedstock/recipe/run_webengine_test.sh
	None INFO bash: /feedstock/recipe/run_webengine_test.sh: No such file or directory
	None INFO done
	None INFO TESTS FAILED: qt-webengine-5.15.9-he2071f7_8.tar.bz2
	```

[PKG-7760]: https://anaconda.atlassian.net/browse/PKG-7760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ